### PR TITLE
Update opentap

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -18,7 +18,7 @@ runs:
   steps:
     - uses: opentap/setup-opentap@v1.0
       with:
-        version: 9.16.4
+        version: 9.23.2-beta.5
     - name: Checkout
       uses: actions/checkout@v2
       with:

--- a/action.yml
+++ b/action.yml
@@ -19,7 +19,7 @@ runs:
     - uses: opentap/setup-opentap@v1.0
       with:
         # this version introduced a change to gitversion behavior. Once the change is released, we should replace this with a release version, and make a new get-gitversion release
-        version: 9.23.1-alpha.1.2
+        version: 9.23.2-beta.16
     - name: Checkout
       uses: actions/checkout@v2
       with:

--- a/action.yml
+++ b/action.yml
@@ -18,7 +18,8 @@ runs:
   steps:
     - uses: opentap/setup-opentap@v1.0
       with:
-        version: 9.23.2-beta.5
+        # this version introduced a change to gitversion behavior. Once the change is released, we should replace this with a release version, and make a new get-gitversion release
+        version: 9.23.1-alpha.1.2
     - name: Checkout
       uses: actions/checkout@v2
       with:


### PR DESCRIPTION
OpenTAP gitversioning behavior has changed slightly in 9.23.2+

This should not be merged until we have tagged v1.1, and there are no more 9.23 patches